### PR TITLE
Fix problem with update including id

### DIFF
--- a/openstack/resource2.py
+++ b/openstack/resource2.py
@@ -645,6 +645,9 @@ class Resource(object):
         :raises: :exc:`~openstack.exceptions.MethodNotSupported` if
                  :data:`Resource.allow_update` is not set to ``True``.
         """
+        # The id cannot be dirty for an update
+        self._body._dirty.discard("id")
+
         # Only try to update if we actually have anything to update.
         if not any([self._body.dirty, self._header.dirty]):
             return self


### PR DESCRIPTION
The update includes the id which is obviously not a field that
can be updated.  I would imagine most services would ignore that,
but it probably isn't good policy.

Partial-bug: #1665495

Bug-ES #9674
http://192.168.15.2/issues/9674

Change-Id: I6c84b549dae53f91d1662f6e41ea632477c7652c
(cherry picked from commit d56535d4d349cd85965c6035904c5b059ca0685c)