### PR TITLE
update params about cluster filter event

### DIFF
--- a/openstack/cluster/v1/event.py
+++ b/openstack/cluster/v1/event.py
@@ -26,8 +26,9 @@ class Event(resource.Resource):
     allow_get = True
 
     _query_mapping = resource.QueryParameters(
-        'oname', 'otype', 'oid', 'cluster_id', 'action', 'level',
-        'sort', 'global_project')
+        'cluster_id', 'action', 'level', 'sort', 'global_project',
+        obj_id='oid', obj_name='oname', obj_type='otype'
+    )
 
     # Properties
     #: Timestamp string (in ISO8601 format) when the event was generated.


### PR DESCRIPTION
This path replaced filter params about cluster filter event to api
specification name rather than db table field name. at the same time,
it not affect existing api that we use.

Bug-ES #10161
http://192.168.15.2/issues/10161